### PR TITLE
Removed module property from library package.json

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -10,7 +10,6 @@
   },
   "homepage": "https://lab.js.org",
   "main": "dist/lab.js",
-  "module": "src/index.js",
   "dependencies": {
     "@babel/runtime": "^7.7.0",
     "common-tags": "^1.8.0",


### PR DESCRIPTION
This PR removes the optional module property from the library's package.json, which prevents Parcel from trying to build the library from source and failing because of the experimental class properties syntax.

The module property may have some benefit in the future as es modules get rolled out natively into the browser, but for now this change will eliminate teh requirement for an app that uses this library to be able to handle the transpilation that's handled by this project's webpack setup.