### PR TITLE
Add a warning to constrainedShuffle

### DIFF
--- a/packages/library/src/util/random/index.js
+++ b/packages/library/src/util/random/index.js
@@ -168,7 +168,7 @@ export class Random {
       if (constraintChecker(candidate)) break
     }
     if (i >= maxIterations) {
-      console.warn('constrainedShuffle could not find a matching candidate after ${maxIterations} iterations')
+      console.warn(`constrainedShuffle could not find a matching candidate after ${maxIterations} iterations`)
     }
     return candidate
   }

--- a/packages/library/src/util/random/index.js
+++ b/packages/library/src/util/random/index.js
@@ -167,6 +167,9 @@ export class Random {
       candidate = this.shuffle(a)
       if (constraintChecker(candidate)) break
     }
+    if (i >= maxIterations) {
+      console.warn('constrainedShuffle could not find a matching candidate after ${maxIterations} iterations')
+    }
     return candidate
   }
 


### PR DESCRIPTION
Hi Felix and co,

I hit a weird bug in a task where I assumed `constrainedShuffle` was working, but it was silently returning a list that didn't match the restrictions after trying `maxIterations` times.

I'm not sure if this is the right way to throw some kind of visible warning, or if you want it to outright throw an exception.

For my case, I think I am going to have to write my own custom shuffler. But this will at least save someone in the future from stumbling around in the dark as long as I did when using `constrainedShuffle`. 🦖Δ