### PR TITLE
add - parseable option strokeWidth at canvas contents

### DIFF
--- a/packages/library/src/canvas.js
+++ b/packages/library/src/canvas.js
@@ -405,6 +405,7 @@ Screen.metadata = {
           angle: { type: 'number' },
           src: {},
           fontSize: { type: 'number' },
+          strokeWidth: { type: 'number' },
         },
       },
     },


### PR DESCRIPTION
After carefully inspection I have figured out I was not capable of updating strokeWidth property in a loop because it wasn't set as parseable.

As lines' width depend on this parameter, it's useful for experiments to be able to vary this property.