### PR TITLE
Enable type-safe custom plugins by allowing context to extend component interface 

### DIFF
--- a/packages/library/src/base/component.ts
+++ b/packages/library/src/base/component.ts
@@ -35,7 +35,7 @@ enum PrivateEventName {
   endUncontrolled = 'end:uncontrolled',
 }
 
-const EventName = { ...PublicEventName, ...PrivateEventName }
+export const EventName = { ...PublicEventName, ...PrivateEventName }
 type EventName = PublicEventName | PrivateEventName
 
 export type ComponentOptions = {
@@ -117,7 +117,7 @@ export class Component {
       () => this.aggregateParameters,
       this.options.parameters,
     )
-    this.internals.plugins = new PluginAPI(this, options.plugins)
+    this.internals.plugins = new PluginAPI<this, EventName>(this, options.plugins)
 
     // Setup diagnostics
     this.internals.timestamps = {}

--- a/packages/library/src/base/component.ts
+++ b/packages/library/src/base/component.ts
@@ -35,7 +35,7 @@ enum PrivateEventName {
   endUncontrolled = 'end:uncontrolled',
 }
 
-export const EventName = { ...PublicEventName, ...PrivateEventName }
+const EventName = { ...PublicEventName, ...PrivateEventName }
 type EventName = PublicEventName | PrivateEventName
 
 export type ComponentOptions = {

--- a/packages/library/src/base/component.ts
+++ b/packages/library/src/base/component.ts
@@ -117,7 +117,7 @@ export class Component {
       () => this.aggregateParameters,
       this.options.parameters,
     )
-    this.internals.plugins = new PluginAPI<EventName>(this, options.plugins)
+    this.internals.plugins = new PluginAPI(this, options.plugins)
 
     // Setup diagnostics
     this.internals.timestamps = {}

--- a/packages/library/src/base/component.ts
+++ b/packages/library/src/base/component.ts
@@ -117,7 +117,10 @@ export class Component {
       () => this.aggregateParameters,
       this.options.parameters,
     )
-    this.internals.plugins = new PluginAPI<this, EventName>(this, options.plugins)
+    this.internals.plugins = new PluginAPI<this, EventName>(
+      this,
+      options.plugins,
+    )
 
     // Setup diagnostics
     this.internals.timestamps = {}

--- a/packages/library/src/base/plugin.ts
+++ b/packages/library/src/base/plugin.ts
@@ -1,10 +1,15 @@
 import { without } from 'lodash'
+import { EventName } from '../core'
 import { Component } from './component'
 
 type PluginEvent = 'plugin:init' | 'plugin:removal'
 
-export type Plugin<T extends Component> = {
-  handle: (context: T, event: string | PluginEvent, data?: any) => Promise<void>
+export type Plugin<T extends Component = Component> = {
+  handle: (
+    context: T,
+    event: EventName | PluginEvent,
+    data?: any,
+  ) => Promise<void>
 }
 
 export class PluginAPI<T extends Component> {
@@ -33,7 +38,7 @@ export class PluginAPI<T extends Component> {
     this.plugins = without(this.plugins, plugin)
   }
 
-  async handle(event: string, data: any) {
+  async handle(event: EventName, data: any) {
     await Promise.all(
       this.plugins.map(p => p.handle(this.context, event, data)),
     )

--- a/packages/library/src/base/plugin.ts
+++ b/packages/library/src/base/plugin.ts
@@ -1,22 +1,17 @@
 import { without } from 'lodash'
-import { EventName } from '../core'
 import { Component } from './component'
 
 type PluginEvent = 'plugin:init' | 'plugin:removal'
 
-export type Plugin<T extends Component = Component> = {
-  handle: (
-    context: T,
-    event: EventName | PluginEvent,
-    data?: any,
-  ) => Promise<void>
+export type Plugin<C extends Component = Component, E = string> = {
+  handle: (context: C, event: E | PluginEvent, data?: any) => Promise<void>
 }
 
-export class PluginAPI<T extends Component> {
-  plugins: Array<Plugin<T>>
-  context: T
+export class PluginAPI<C extends Component = Component, E = string> {
+  plugins: Array<Plugin<C, E>>
+  context: C
 
-  constructor(context: T, plugins: Array<Plugin<T>> = []) {
+  constructor(context: C, plugins: Array<Plugin<C, E>> = []) {
     this.context = context
     this.plugins = plugins
 
@@ -28,17 +23,17 @@ export class PluginAPI<T extends Component> {
     this.context.internals.emitter.on('*', this.handle)
   }
 
-  add(plugin: Plugin<T>) {
+  add(plugin: Plugin<C, E>) {
     this.plugins.push(plugin)
     plugin.handle(this.context, 'plugin:init')
   }
 
-  remove(plugin: Plugin<T>) {
+  remove(plugin: Plugin<C, E>) {
     plugin.handle(this.context, 'plugin:removal')
     this.plugins = without(this.plugins, plugin)
   }
 
-  async handle(event: EventName, data: any) {
+  async handle(event: E, data: any) {
     await Promise.all(
       this.plugins.map(p => p.handle(this.context, event, data)),
     )

--- a/packages/library/src/base/plugin.ts
+++ b/packages/library/src/base/plugin.ts
@@ -1,7 +1,7 @@
 import { without } from 'lodash'
 import { Component } from './component'
 
-type PluginEvent = 'plugin:init' | 'plugin:removal'
+type PluginEvent = 'plugin:add' | 'plugin:remove'
 
 export class Plugin<C extends Component = Component, E = string> {
   async handle(context: C, event: E | PluginEvent, data?: any) {}
@@ -16,7 +16,7 @@ export class PluginAPI<C extends Component = Component, E = string> {
     this.plugins = plugins
 
     // Initialize existing plugins
-    this.plugins.forEach(p => p.handle(this.context, 'plugin:init'))
+    this.plugins.forEach(p => p.handle(this.context, 'plugin:add'))
 
     // Setup event handlers
     this.handle = this.handle.bind(this)
@@ -25,11 +25,11 @@ export class PluginAPI<C extends Component = Component, E = string> {
 
   add(plugin: Plugin<C, E>) {
     this.plugins.push(plugin)
-    plugin.handle(this.context, 'plugin:init')
+    plugin.handle(this.context, 'plugin:add')
   }
 
   remove(plugin: Plugin<C, E>) {
-    plugin.handle(this.context, 'plugin:removal')
+    plugin.handle(this.context, 'plugin:remove')
     this.plugins = without(this.plugins, plugin)
   }
 

--- a/packages/library/src/base/plugin.ts
+++ b/packages/library/src/base/plugin.ts
@@ -3,19 +3,15 @@ import { Component } from './component'
 
 type PluginEvent = 'plugin:init' | 'plugin:removal'
 
-export type Plugin<T = string> = {
-  handle: (
-    context: Component,
-    event: T | PluginEvent,
-    data?: any,
-  ) => Promise<void>
+export type Plugin<T extends Component> = {
+  handle: (context: T, event: string | PluginEvent, data?: any) => Promise<void>
 }
 
-export class PluginAPI<T = string> {
+export class PluginAPI<T extends Component> {
   plugins: Array<Plugin<T>>
-  context: Component
+  context: T
 
-  constructor(context: Component, plugins: Array<Plugin<T>> = []) {
+  constructor(context: T, plugins: Array<Plugin<T>> = []) {
     this.context = context
     this.plugins = plugins
 
@@ -37,7 +33,7 @@ export class PluginAPI<T = string> {
     this.plugins = without(this.plugins, plugin)
   }
 
-  async handle(event: T, data: any) {
+  async handle(event: string, data: any) {
     await Promise.all(
       this.plugins.map(p => p.handle(this.context, event, data)),
     )

--- a/packages/library/src/base/plugin.ts
+++ b/packages/library/src/base/plugin.ts
@@ -3,8 +3,8 @@ import { Component } from './component'
 
 type PluginEvent = 'plugin:init' | 'plugin:removal'
 
-export type Plugin<C extends Component = Component, E = string> = {
-  handle: (context: C, event: E | PluginEvent, data?: any) => Promise<void>
+export class Plugin<C extends Component = Component, E = string> {
+  async handle(context: C, event: E | PluginEvent, data?: any) {}
 }
 
 export class PluginAPI<C extends Component = Component, E = string> {

--- a/packages/library/src/core/component.ts
+++ b/packages/library/src/core/component.ts
@@ -12,7 +12,6 @@ import { Controller } from './controller'
 import { DomConnection, EventMap } from './events/index'
 import { Timeline, SerializedItem as SerializedTimelineItem } from './timeline'
 import { FrameTimeout, timingParameters } from './timing/timeout'
-import { plugins } from '..'
 
 type Media = {
   images: string[]

--- a/packages/library/src/core/component.ts
+++ b/packages/library/src/core/component.ts
@@ -5,12 +5,14 @@ import {
   ComponentOptions as BaseComponentOptions,
   Status,
 } from '../base/component'
+import { Plugin } from '../plugins'
 import { Store } from '../data'
 import { Random, RNGOptions } from '../util/random'
 import { Controller } from './controller'
 import { DomConnection, EventMap } from './events/index'
 import { Timeline, SerializedItem as SerializedTimelineItem } from './timeline'
 import { FrameTimeout, timingParameters } from './timing/timeout'
+import { plugins } from '..'
 
 type Media = {
   images: string[]
@@ -31,9 +33,13 @@ const componentDefaults = {
   scrollTop: false,
   // Legacy shim
   datastore: <Store | undefined>undefined,
+  plugins: <Plugin[] | undefined>undefined,
 }
 
-export type ComponentOptions = BaseComponentOptions & typeof componentDefaults
+export type ComponentOptions = Omit<BaseComponentOptions, 'plugins'> &
+  typeof componentDefaults
+
+export type testPluginOptions = ComponentOptions['plugins']
 
 export class Component extends BaseComponent {
   options!: ComponentOptions

--- a/packages/library/src/core/component.ts
+++ b/packages/library/src/core/component.ts
@@ -38,8 +38,6 @@ const componentDefaults = {
 export type ComponentOptions = Omit<BaseComponentOptions, 'plugins'> &
   typeof componentDefaults
 
-export type testPluginOptions = ComponentOptions['plugins']
-
 export class Component extends BaseComponent {
   options!: ComponentOptions
   state: any

--- a/packages/library/src/plugins/debug.ts
+++ b/packages/library/src/plugins/debug.ts
@@ -366,7 +366,7 @@ export default class Debug {
 
   async handle(context: Component, event: string) {
     switch (event) {
-      case 'plugin:init':
+      case 'plugin:add':
         return this.onInit(context)
       case 'prepare':
         return await this.onPrepare()

--- a/packages/library/src/plugins/index.ts
+++ b/packages/library/src/plugins/index.ts
@@ -1,8 +1,10 @@
 // Plugin interface definition
 import { Plugin as BasePlugin } from '../base/plugin'
 import { Component, EventName } from '../core'
-export type Plugin = BasePlugin<Component, EventName>
-
+export type Plugin<
+  C extends Component = Component,
+  E extends EventName = EventName,
+> = BasePlugin<C, E>
 export { default as Debug, DebugPluginOptions } from './debug'
 export { default as Download, DownloadPluginOptions } from './download'
 export { default as Fullscreen, FullscreenPluginOptions } from './fullscreen'

--- a/packages/library/src/plugins/index.ts
+++ b/packages/library/src/plugins/index.ts
@@ -1,5 +1,7 @@
 // Plugin interface definition
-export { Plugin } from '../base/plugin'
+import { Plugin as BasePlugin } from '../base/plugin'
+import { Component, EventName } from '../core'
+export type Plugin = BasePlugin<Component, EventName>
 
 export { default as Debug, DebugPluginOptions } from './debug'
 export { default as Download, DownloadPluginOptions } from './download'


### PR DESCRIPTION
While trying out the new beta version, I discovered that the hard-coded typing of the `context` argument in the `Plugin` interface to the private `Component` interface was making it difficult to implement custom plugins.

Here I propose a solution where the `context` of a plugin is flexible based on the type of component it is attached to. This allows user-created plugins without type overrides, and has the benefit of allowing plugins that rely on specific features of certain compenents (e.g. a Sequence's content array), to be created in a safe manner.

Note: I did have to remove the generic typing of the event string. However, I couldn't find a place in the library where anything but the `EventName` enum was used here, so I replaced it. 