### PR TITLE
export PasableOption from base

### DIFF
--- a/packages/library/src/base/component.ts
+++ b/packages/library/src/base/component.ts
@@ -54,7 +54,7 @@ export type ComponentOptions = {
 
 type CoercionType = 'object' | 'array' | 'string' | 'number' | 'boolean'
 
-type ParsableOption = {
+export type ParsableOption = {
   type?: CoercionType
   content?: {
     '*'?: CoercionType | {}

--- a/packages/library/src/core/index.ts
+++ b/packages/library/src/core/index.ts
@@ -10,4 +10,5 @@ export {
 
 export {
   PublicEventName as EventName, //
+  ParsableOption,
 } from '../base/component'


### PR DESCRIPTION
There's a handy utility we've developed to dynamically generate and then export different classes of Screens. In the new update, this utility is running into a type issue that appears to due to our library trying to re-export a type containing this option that isn't exported from lab.js itself (https://github.com/microsoft/TypeScript/issues/5711).

Here's the gist:

```typescript
// error: Return type of exported function has or is using name 'ParsableOption' from external module "C:/Users/danomorrison/work/src2/node_modules/lab.js/dist/base/component" but cannot be named."
function componentToScreen<T>(Component: React.FC<T>){
type ComponentScreenOptions = html.ScreenOptions & T

return Class ComponentScreen {
/// get props for instance and render component, etc.
}

}

export const exampleScreen = componentToScreen(ExampleComponent)
```