### PR TITLE
Add defaults to type of `core.Controller`

### DIFF
--- a/packages/library/src/base/controller.ts
+++ b/packages/library/src/base/controller.ts
@@ -11,7 +11,7 @@ export class Controller extends Emitter {
   currentStack: Array<Component>
 
   global: Record<string, any>
-  context: object
+  context: Record<string, any>
   private lock: Lock
 
   flipHandlers: Function[]
@@ -23,7 +23,7 @@ export class Controller extends Emitter {
   }: {
     root: Component
     global?: Record<string, any>
-    initialContext?: Object
+    initialContext?: Record<string, any>
   }) {
     super('controller')
 

--- a/packages/library/src/base/controller.ts
+++ b/packages/library/src/base/controller.ts
@@ -4,18 +4,13 @@ import { Lock } from './util/lock'
 import { Emitter } from './util/emitter'
 import { Store } from '../data'
 
-type global = {
-  store?: Store
-  [key: string]: any
-}
-
 export class Controller extends Emitter {
   root!: Component
   iterable: FlipIterable
   iterator: FlipIterator<Component>
   currentStack: Array<Component>
 
-  global: global
+  global: Record<string, any>
   context: object
   private lock: Lock
 
@@ -27,7 +22,7 @@ export class Controller extends Emitter {
     initialContext = {},
   }: {
     root: Component
-    global?: Object
+    global?: Record<string, any>
     initialContext?: Object
   }) {
     super('controller')

--- a/packages/library/src/core/component.ts
+++ b/packages/library/src/core/component.ts
@@ -87,12 +87,8 @@ export class Component extends BaseComponent {
     await super.prepare(directCall)
 
     await Promise.all([
-      this.internals.controller.global.cache.images.getAll(
-        this.options.media?.images ?? [],
-      ),
-      this.internals.controller.global.cache.audio.getAll(
-        this.options.media?.audio ?? [],
-      ),
+      this.global.cache.images.getAll(this.options.media?.images ?? []),
+      this.global.cache.audio.getAll(this.options.media?.audio ?? []),
     ])
 
     // Finalize timeline
@@ -200,14 +196,7 @@ export class Component extends BaseComponent {
   }
 
   get global() {
-    if (this.#controller) {
-      return this.#controller.global
-    } else {
-      console.error(
-        'Trying to retrieve global state but no controller available',
-      )
-      return {}
-    }
+    return this.#controller.global
   }
 
   // Timekeeping ------------------------------------------

--- a/packages/library/src/core/component.ts
+++ b/packages/library/src/core/component.ts
@@ -46,6 +46,8 @@ export class Component extends BaseComponent {
 
   parent?: Component
 
+  #controller!: Controller
+
   constructor(options: Partial<ComponentOptions> = {}) {
     super({
       ...cloneDeep(componentDefaults),
@@ -195,6 +197,17 @@ export class Component extends BaseComponent {
     this.internals.domConnection.teardown()
     await super.lock({ timestamp })
     this.status = Status.locked
+  }
+
+  get global() {
+    if (this.#controller) {
+      return this.#controller.global
+    } else {
+      console.error(
+        'Trying to retrieve global state but no controller available',
+      )
+      return {}
+    }
   }
 
   // Timekeeping ------------------------------------------

--- a/packages/library/src/core/controller.ts
+++ b/packages/library/src/core/controller.ts
@@ -1,6 +1,6 @@
 import { Component } from '../base/component'
 import { Controller as BaseController } from '../base/controller'
-import { Store } from '../data/store'
+import { Row, Store } from '../data/store'
 import { ImageCache, AudioCache } from './cache'
 
 declare global {
@@ -9,7 +9,22 @@ declare global {
   }
 }
 
+export interface CoreGlobal {
+  rootEl: Element
+  datastore: Store<Row>
+  state: Row
+  cache: {
+    images: ImageCache
+    audio: AudioCache
+  }
+  random: Record<string, any>
+  audioContext: AudioContext
+  [key: string]: any
+}
+
 export class Controller extends BaseController {
+  global!: CoreGlobal
+
   constructor({ root, el }: { root: Component; el?: Element }) {
     const audioContext = new (window.AudioContext ??
       window.webkitAudioContext)()

--- a/packages/library/src/core/controller.ts
+++ b/packages/library/src/core/controller.ts
@@ -9,7 +9,7 @@ declare global {
   }
 }
 
-export interface CoreGlobal {
+export interface ControllerGlobal {
   rootEl: Element
   datastore: Store<Row>
   state: Row
@@ -23,7 +23,7 @@ export interface CoreGlobal {
 }
 
 export class Controller extends BaseController {
-  global!: CoreGlobal
+  global!: ControllerGlobal
 
   constructor({ root, el }: { root: Component; el?: Element }) {
     const audioContext = new (window.AudioContext ??

--- a/packages/library/src/core/timeline/items/audio.ts
+++ b/packages/library/src/core/timeline/items/audio.ts
@@ -91,7 +91,7 @@ const defaultPayload = {
   pan: 0,
   rampUp: 0,
   rampDown: 0,
-  panningModel: 'equalpower',
+  panningModel: 'equalpower' as PanningModelType,
 }
 
 type nodeOrder = {

--- a/packages/library/src/plugins/debug.ts
+++ b/packages/library/src/plugins/debug.ts
@@ -319,8 +319,8 @@ const snapshot = (context: Component, target?: string[]) => {
       .map((c: Component) => c.id)
 
   // Get data and state
-  const data = context!.global.datastore.data
-  const state = context!.state
+  const data = context.global.datastore.data
+  const state = context.state
 
   window.sessionStorage.setItem(
     'labjs-debug-snapshot',

--- a/packages/library/src/plugins/transmit.ts
+++ b/packages/library/src/plugins/transmit.ts
@@ -61,7 +61,7 @@ export default class Transmit implements Plugin {
     switch (event) {
       case 'prepare':
         const controller = context.internals.controller
-        const ds = controller.global.datastore as Store
+        const ds = controller.global.datastore
 
         // Setup incremental transmission logic
         this.connection = new Connection(ds, this.#url, {


### PR DESCRIPTION
This PR updates the typing of `core.Controller` and `core.Component` to include the default values that are attached during preparation (`datastore`, `cache`, etc.).

This makes it a little easier to work with the Controller and, by extension, `Component.global`, by including all of the default values that will always be there, addressing the issue in https://github.com/FelixHenninger/lab.js/issues/179

In addition, I performed a little type cleanup, including removing the `Store` field from the base Controller's global type, which appeared unused, and removing some type checks and forces that were unnecessary with the new typing of Controller.   