### PR TITLE
ensure Debug plugin returns void

### DIFF
--- a/packages/library/src/plugins/debug.ts
+++ b/packages/library/src/plugins/debug.ts
@@ -371,7 +371,7 @@ export default class Debug {
       case 'prepare':
         return await this.onPrepare()
       default:
-        return null
+        return
     }
   }
 


### PR DESCRIPTION
I don't know how this snuck past the typescript compiler, but it looks like the Debug plugin is the only plugin in the repo that can return `null` instead of just `void`. This causes type issues when trying to actually include the Debug plugin in a typescript lab.js file.

It looks like this is just an artifact of a much earlier time and can be safely updated