### PR TITLE
fixed bug where all events had to have handlers in hooks

### DIFF
--- a/packages/library/src/base/component.ts
+++ b/packages/library/src/base/component.ts
@@ -49,7 +49,7 @@ export type ComponentOptions = {
   tardy: boolean
   correctResponse: string
   plugins?: Plugin[]
-  hooks?: { [N in EventName]: EventHandler }
+  hooks?: { [N in EventName]?: EventHandler }
   data: any
 }
 


### PR DESCRIPTION
I was trying to use the `hooks` option to set some logic today and discovered that the typing is wrong currently and requires handlers to be provided for ALL event types if using this option:

```typescript
// ...
        hooks: {
          run: eventHandler,
        },
// Throwing error related to missing ""before:prepare", prepare, render, end", etc.
// ...

This type change allows the previous code to be valid