### PR TITLE
Fix TypeScript Build

### DIFF
--- a/packages/library/tsconfig.json
+++ b/packages/library/tsconfig.json
@@ -18,7 +18,7 @@
     "outDir": "dist/types",                   /* Redirect output structure to the directory. */
     "rootDir": "src",                         /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "composite": true,                        /* Enable project compilation */
-    "tsBuildInfoFile": "./",                  /* Specify file to store incremental compilation information */
+    // "tsBuildInfoFile": "./",                  /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */


### PR DESCRIPTION
I tried to build the core library on my machine and it was failing:

```shell
error TS5033: Could not write file '/local/home/Developer/lab.js/packages/library': EISDIR: illegal operation on a directory, open '/local/home/Developer/lab.js/packages/library'.
```

This issue is due to the `tsBuildInfoFile` setting in `tsconfig,json`. I commented this out and it works as expected.  From what I understand in [the docs](https://www.typescriptlang.org/tsconfig#tsBuildInfoFile), this should refer to a file if set, which makes sense considering the error message.