### PR TITLE
Resolve Conflict with .container Class in LABJS

### DIFF
--- a/packages/library/src/starterkit/index.html
+++ b/packages/library/src/starterkit/index.html
@@ -13,7 +13,7 @@
   </head>
 
   <body>
-    <!-- If you'd rather have a labjs-container with a fixed width
+    <!-- If you'd rather have a container with a fixed width
        and variable height, try removing the fullscreen class below -->
     <div class="labjs-container fullscreen">
       <header class="content-vertical-center content-horizontal-center">

--- a/packages/library/src/starterkit/index.html
+++ b/packages/library/src/starterkit/index.html
@@ -13,9 +13,9 @@
   </head>
 
   <body>
-    <!-- If you'd rather have a container with a fixed width
+    <!-- If you'd rather have a labjs-container with a fixed width
        and variable height, try removing the fullscreen class below -->
-    <div class="container fullscreen">
+    <div class="labjs-container fullscreen">
       <header class="content-vertical-center content-horizontal-center">
         <div>
           <!-- You could put a title here,

--- a/packages/library/src/starterkit/lib/lab.css
+++ b/packages/library/src/starterkit/lib/lab.css
@@ -1,11 +1,11 @@
 /* Basic configuration */
 :root {
   /* Layout */
-  --width-container: 900px;
-  --width-min-container: 320px;
+  --width-labjs-container: 900px;
+  --width-min-labjs-container: 320px;
   --height-min-header-footer: 8vh;
   --padding-internal: 24px;
-  --border-radius-container: 5px;
+  --border-radius-labjs-container: 5px;
   --border-radius-content: 4px;
   /* Typography */
   --font-family: 'Arial', sans-serif;
@@ -42,12 +42,12 @@ body {
   background: var(--color-background);
 }
 
-.container {
-  min-width: var(--width-min-container);
+.labjs-container {
+  min-width: var(--width-min-labjs-container);
   min-height: var(--height-min-header-footer);
   /* Use page-style layout by default */
   margin: var(--padding-internal) auto;
-  width: var(--width-container);
+  width: var(--width-labjs-container);
 }
 .overlay {
   position: fixed;
@@ -85,7 +85,7 @@ main {
 }
 
 /* Fullscreen layout */
-.container.fullscreen {
+.labjs-container.fullscreen {
   /* Full screen minus margins */
   margin: var(--padding-internal);
   min-height: calc(100vh - 2 * var(--padding-internal));
@@ -94,18 +94,18 @@ main {
   display: flex;
   flex-direction: column;
 }
-.container.fullscreen main {
+.labjs-container.fullscreen main {
   /* Flex positioning */
   flex: 1;
 }
 
 /* Frameless layout */
-.container.frameless {
+.labjs-container.frameless {
   margin: 0 auto;
   border: none;
   border-radius: 0;
 }
-.container.fullscreen.frameless {
+.labjs-container.fullscreen.frameless {
   margin: 0;
   width: 100%;
   min-height: 100vh;
@@ -113,7 +113,7 @@ main {
 
 /* Remove frame on small screens */
 @media (max-width: 600px), (max-height: 600px) {
-  .container.fullscreen {
+  .labjs-container.fullscreen {
     margin: 0;
     border: none;
     border-radius: 0;
@@ -123,9 +123,9 @@ main {
 }
 
 /* Borders and backgrounds */
-.container {
+.labjs-container {
   border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-container);
+  border-radius: var(--border-radius-labjs-container);
 }
 header {
   border-bottom: 1px solid var(--color-border-internal);
@@ -189,15 +189,15 @@ kbd.big {
 }
 .w-s {
   width: 100%;
-  max-width: var(--width-min-container);
+  max-width: var(--width-min-labjs-container);
 }
 .w-m {
   width: 100%;
-  max-width: calc(1.5 * var(--width-min-container));
+  max-width: calc(1.5 * var(--width-min-labjs-container));
 }
 .w-l {
   width: 100%;
-  max-width: calc(2 * var(--width-min-container));
+  max-width: calc(2 * var(--width-min-labjs-container));
 }
 /* Block alignment based on flexbox */
 .content-vertical-top,
@@ -475,12 +475,12 @@ table .sticky-top {
 }
 
 /* Width, for some reason, needs to be set explicitly */
-.container.fullscreen .popover {
+.labjs-container.fullscreen .popover {
   width: calc(100vw - 2 * var(--padding-internal));
 }
 /* Repeated for frameless mode on small screens */
 @media (max-width: 600px), (max-height: 600px) {
-  .container.fullscreen .popover {
+  .labjs-container.fullscreen .popover {
     width: 100vw;
   }
 }
@@ -490,8 +490,8 @@ table .sticky-top {
   margin: 0 auto;
 }
 
-.container:not(.fullscreen) .popover {
-  width: var(--width-container);
+.labjs-container:not(.fullscreen) .popover {
+  width: var(--width-labjs-container);
 }
 
 /* Slide in from the top */

--- a/packages/library/src/starterkit/lib/lab.css
+++ b/packages/library/src/starterkit/lib/lab.css
@@ -1,11 +1,11 @@
 /* Basic configuration */
 :root {
   /* Layout */
-  --width-labjs-container: 900px;
-  --width-min-labjs-container: 320px;
+  --width-container: 900px;
+  --width-min-container: 320px;
   --height-min-header-footer: 8vh;
   --padding-internal: 24px;
-  --border-radius-labjs-container: 5px;
+  --border-radius-container: 5px;
   --border-radius-content: 4px;
   /* Typography */
   --font-family: 'Arial', sans-serif;
@@ -43,11 +43,11 @@ body {
 }
 
 .labjs-container {
-  min-width: var(--width-min-labjs-container);
+  min-width: var(--width-min-container);
   min-height: var(--height-min-header-footer);
   /* Use page-style layout by default */
   margin: var(--padding-internal) auto;
-  width: var(--width-labjs-container);
+  width: var(--width-container);
 }
 .overlay {
   position: fixed;
@@ -125,7 +125,7 @@ main {
 /* Borders and backgrounds */
 .labjs-container {
   border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-labjs-container);
+  border-radius: var(--border-radius-container);
 }
 header {
   border-bottom: 1px solid var(--color-border-internal);
@@ -189,15 +189,15 @@ kbd.big {
 }
 .w-s {
   width: 100%;
-  max-width: var(--width-min-labjs-container);
+  max-width: var(--width-min-container);
 }
 .w-m {
   width: 100%;
-  max-width: calc(1.5 * var(--width-min-labjs-container));
+  max-width: calc(1.5 * var(--width-min-container));
 }
 .w-l {
   width: 100%;
-  max-width: calc(2 * var(--width-min-labjs-container));
+  max-width: calc(2 * var(--width-min-container));
 }
 /* Block alignment based on flexbox */
 .content-vertical-top,
@@ -491,7 +491,7 @@ table .sticky-top {
 }
 
 .labjs-container:not(.fullscreen) .popover {
-  width: var(--width-labjs-container);
+  width: var(--width-container);
 }
 
 /* Slide in from the top */


### PR DESCRIPTION
### Description 
In LABJS, the `.container` class is used for the builder, potentially causing conflicts with HTML/CSS code.

This problem affects not just experienced programmers writing CSS code within LABJS, but also people with less knowledge who are generating code with tools like ChatGPT. 

This pull request proposes a solution to address this conflict, enhancing user experience and code compatibility.

### Example : 

There are many ways to show the issue. The most event one is by asking a question to ChatGPT, where it can reply by using the `.container` class.

I queried ChatGPT with:

![image](https://github.com/FelixHenninger/lab.js/assets/45522552/0b04a687-ac0d-4c29-b4a8-ea9f06f42886)
And it responded with:

![image](https://github.com/FelixHenninger/lab.js/assets/45522552/42179c85-656a-4d1b-9a80-b967079bd471)
![image](https://github.com/FelixHenninger/lab.js/assets/45522552/6a5ae140-30ea-42ac-81f1-24991d917574)

Identifying why the `.container` class was overridden is not always easy, as it necessitates inspecting the console, which is not easily accessible for researchers, the primary users of the program.

### Changes : 

1. Renamed the `.container` class to `.labjs-container` throughout the LABJS codebase to avoid conflicts.
2. Updated the reference of the `.container` class in the index.html file to reflect the new name `.labjs-container`.
