### PR TITLE
chore: better error in flipIterable.ts

### DIFF
--- a/packages/library/src/base/util/iterators/flipIterable.ts
+++ b/packages/library/src/base/util/iterators/flipIterable.ts
@@ -148,7 +148,7 @@ export class FlipIterable {
 
                 // TODO: Ensure that .lock() is called on aborted components
               } else {
-                console.error(`Error running`, c)
+                console.error(`Error running`, error, c)
                 throw error
               }
             }
@@ -272,7 +272,7 @@ const stopOutgoing = async function (
       await c.end(flipData.reason, { ...flipData, controlled: true })
       context = c.leaveContext(context)
     } catch (error) {
-      console.error(`Error ending`, c)
+      console.error(`Error ending`, error, c)
       throw error
     }
   }


### PR DESCRIPTION
This improves the error logging in flipIterable.ts by adding the actual error to the `console.error`.