### PR TITLE
fix: emitter debug logs

### DIFF
--- a/packages/library/src/base/component.ts
+++ b/packages/library/src/base/component.ts
@@ -120,7 +120,7 @@ export class Component {
     this.data = options.data ?? {}
 
     // Setup emitter
-    this.#emitter = new Emitter(id, { debug, context: this })
+    this.#emitter = new Emitter(this, { debug, context: this })
     this.on = (...args) => this.#emitter.on(...args)
     this.off = (...args) => this.#emitter.off(...args)
 

--- a/packages/library/src/base/util/emitter.ts
+++ b/packages/library/src/base/util/emitter.ts
@@ -2,6 +2,8 @@
 // by Jason Miller, see https://github.com/developit/mitt .
 // Any mistakes, of course, are entirely my own.
 
+import { Component } from "../component"
+
 export type EventHandler = (...payload: any[]) => void
 type WildCardEventHandler<T> = (event: T, ...payload: any[]) => void
 
@@ -31,16 +33,16 @@ const getMethodName = function (event: string) {
 }
 
 export class Emitter<T extends string = string> {
-  id?: string
+  component: Component
   options: EmitterOptions
   #context: object
   #hooks: EventHandlerMap<T>
 
   constructor(
-    id?: string,
+    component: Component,
     options: EmitterOptions = { debug: false, context: undefined },
   ) {
-    this.id = id
+    this.component = component
     this.options = options
     this.#hooks = new Map()
     this.#context = options.context ?? this
@@ -48,7 +50,7 @@ export class Emitter<T extends string = string> {
 
   async trigger(event: T, ...payload: any[]) {
     if (this.options.debug) {
-      console.info(`Caught ${event} on ${this.id}, data`, payload)
+      console.info(`Caught ${event} on ${this.component.id}, data`, payload)
     }
 
     // Trigger local method, if available


### PR DESCRIPTION
Currently, emitter logs do not properly log the component ID. This is because the ID is passed in to the Emitter constructor when the Component is constructed [here](https://github.com/FelixHenninger/lab.js/blob/main/packages/library/src/base/component.ts#L123). At this point, the Component ID is undefined unless specifically passed. The component's ID that is set later in study prep is not reflected in Emitter.

This fixes the issue by passing in the component reference to the Emitter and accessing the ID through the Component. Also changed the first argument to the required instead of optional to simplify the interface.